### PR TITLE
No NDK specify

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 30
 
-    ndkVersion ndkSelectedVersion
-
     defaultConfig {
         applicationId "com.panoramagl.sample"
         minSdkVersion 15

--- a/build.gradle
+++ b/build.gradle
@@ -4,23 +4,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
-}
-
-ext {
-    if (System.env.CI == "true") {
-        println "I run on Github CI"
-        ndkSelectedVersion = "21.3.6528147"
-    } else if (System.env.JITPACK == "true") {
-        println "I run on JITPACK CI"
-        ndkSelectedVersion = "21.1.6352462"
-    } else {
-        println "I run somewhere"
-        ndkSelectedVersion = "21.3.6528147"
-    }
-
-    println "ndkSelectedVersion=$ndkSelectedVersion"
 }
 
 allprojects {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 30
 
-    ndkVersion ndkSelectedVersion
-
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 30


### PR DESCRIPTION
Should be fixed and
not necessary with android gradle plugin 4.1.0 (see also https://issuetracker.google.com/issues/144111441