### PR TITLE
Fixed PLHotspot.java setX and setY

### DIFF
--- a/library/src/main/java/com/panoramagl/hotspots/PLHotspot.java
+++ b/library/src/main/java/com/panoramagl/hotspots/PLHotspot.java
@@ -247,10 +247,19 @@ public class PLHotspot extends PLSceneElementBase implements PLIHotspot {
 
     @Override
     public void setX(float x) {
+        if(this.getX() != x)
+		{
+			super.setX(x);
+			hasChangedCoordProperty = true;
+		}
     }
 
     @Override
     public void setY(float y) {
+        if(this.getY() != y){
+			super.setY(y);
+			hasChangedCoordProperty = true;
+		}
     }
 
     @Override

--- a/library/src/main/java/com/panoramagl/hotspots/PLHotspot.java
+++ b/library/src/main/java/com/panoramagl/hotspots/PLHotspot.java
@@ -247,19 +247,18 @@ public class PLHotspot extends PLSceneElementBase implements PLIHotspot {
 
     @Override
     public void setX(float x) {
-        if(this.getX() != x)
-		{
-			super.setX(x);
-			hasChangedCoordProperty = true;
-		}
+        if(this.getX() != x) {
+	    super.setX(x);
+	    hasChangedCoordProperty = true;
+	}
     }
 
     @Override
     public void setY(float y) {
-        if(this.getY() != y){
-			super.setY(y);
-			hasChangedCoordProperty = true;
-		}
+        if(this.getY() != y) {
+	    super.setY(y);
+	    hasChangedCoordProperty = true;
+	}
     }
 
     @Override


### PR DESCRIPTION
These missing implementations didn't permit to set properly the x and y of an hotspot, causing all the hotspots to be always at x:0.0 and y:0.0