### PR TITLE
Ndk remove 'armeabi' and introduce 'arm64-v8a'

### DIFF
--- a/library/src/main/jni/Application.mk
+++ b/library/src/main/jni/Application.mk
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-APP_ABI := armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64


### PR DESCRIPTION
https://developer.android.com/ndk/guides/abis
Historically the NDK supported ARMv5 (armeabi), and 32-bit and 64-bit MIPS, but support for these ABIs was removed in NDK r17