### PR TITLE
Change Group id

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = "Panorama GL"
+rootProject.name = "Panorama-GL"
 include ':app', ':library'


### PR DESCRIPTION
To avoid: Invalid publication 'release': groupId (Panorama GL) is not a valid Maven identifier ([A-Za-z0-9_\-.]+).