### PR TITLE
Device orientation

### DIFF
--- a/app/src/main/java/com/panoramagl/sample/MainActivity.kt
+++ b/app/src/main/java/com/panoramagl/sample/MainActivity.kt
@@ -30,6 +30,7 @@ class MainActivity : AppCompatActivity(), HotSpotListener {
 
         plManager = PLManager(this).apply {
             setContentView(binding.contentView)
+
             onCreate()
             isAccelerometerEnabled = false
             isInertiaEnabled = false
@@ -118,6 +119,7 @@ class MainActivity : AppCompatActivity(), HotSpotListener {
         }
         plManager.panorama = panorama
         currentIndex = index
+        plManager.startSensorialRotation()
     }
 
     override fun onHotspotClick(identifier: Long) {

--- a/library/src/main/java/com/panoramagl/PLManager.kt
+++ b/library/src/main/java/com/panoramagl/PLManager.kt
@@ -7,6 +7,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.opengl.GLSurfaceView
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.DisplayMetrics
@@ -37,6 +38,7 @@ import com.panoramagl.transitions.PLITransition
 import com.panoramagl.transitions.PLTransitionListener
 import timber.log.Timber
 import javax.microedition.khronos.opengles.GL10
+
 
 @Suppress("unused")
 open class PLManager(private val context: Context) : PLIView, SensorEventListener, OnDoubleTapListener {
@@ -131,6 +133,20 @@ open class PLManager(private val context: Context) : PLIView, SensorEventListene
             SensorManager.SENSOR_DELAY_FASTEST
         else
             SensorManager.SENSOR_DELAY_GAME
+
+        val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.display?.rotation
+        } else {
+            (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.orientation
+        }
+
+        mCurrentDeviceOrientation = when (rotation) {
+            Surface.ROTATION_0 -> UIDeviceOrientation.UIDeviceOrientationPortrait
+            Surface.ROTATION_90 -> UIDeviceOrientation.UIDeviceOrientationLandscapeLeft
+            Surface.ROTATION_180 -> UIDeviceOrientation.UIDeviceOrientationPortraitUpsideDown
+            Surface.ROTATION_270 -> UIDeviceOrientation.UIDeviceOrientationLandscapeRight
+            else -> UIDeviceOrientation.UIDeviceOrientationPortrait
+        }
     }
 
     fun onCreate() {
@@ -195,7 +211,6 @@ open class PLManager(private val context: Context) : PLIView, SensorEventListene
         mShakeThreshold = PLConstants.kShakeThreshold.toFloat()
         mIsValidForTransition = false
         mTouchStatus = PLTouchStatus.PLTouchStatusNone
-        mCurrentDeviceOrientation = UIDeviceOrientation.UIDeviceOrientationPortrait
         mFileDownloaderManager = PLFileDownloaderManager()
         mIsZoomEnabled = true
         this.reset()

--- a/library/src/main/java/com/panoramagl/PLViewListener.kt
+++ b/library/src/main/java/com/panoramagl/PLViewListener.kt
@@ -13,80 +13,80 @@ import com.panoramagl.transitions.PLITransition
 
 @Suppress("UNUSED_PARAMETER")
 abstract class PLViewListener {
-    fun onTouchesBegan(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onTouchesMoved(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onTouchesEnded(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
+    open fun onTouchesBegan(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onTouchesMoved(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onTouchesEnded(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
         return true
     }
 
-    fun onDidBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
+    open fun onDidBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
         return true
     }
 
-    fun onDidMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
+    open fun onDidMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
         return true
     }
 
-    fun onDidEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?): Boolean {
+    open fun onDidEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?): Boolean {
         return true
     }
 
-    fun onDidAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?) {}
-    fun onShouldBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
+    open fun onDidAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?) {}
+    open fun onShouldBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
         return true
     }
 
-    fun onDidBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
+    open fun onDidBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
         return true
     }
 
-    fun onDidRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onDidEndInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldBeingScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
+    open fun onDidRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onDidEndInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldBeingScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
         return true
     }
 
-    fun onDidBeginScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onDidEndScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldBeginZooming(view: PLIView?): Boolean {
+    open fun onDidBeginScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onDidEndScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldBeginZooming(view: PLIView?): Boolean {
         return true
     }
 
-    fun onDidBeginZooming(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean): Boolean {
+    open fun onDidBeginZooming(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean): Boolean {
         return true
     }
 
-    fun onDidRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean) {}
-    fun onDidEndZooming(view: PLIView?) {}
-    fun onShouldReset(view: PLIView?): Boolean {
+    open fun onDidRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean) {}
+    open fun onDidEndZooming(view: PLIView?) {}
+    open fun onShouldReset(view: PLIView?): Boolean {
         return true
     }
 
-    fun onDidReset(view: PLIView?) {}
-    fun onDidBeginCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
-    fun onDidEndCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
-    fun onDidResetCamera(view: PLIView?, sender: Any?, camera: PLICamera?) {}
-    fun onDidLookAtCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, animated: Boolean) {}
-    fun onDidRotateCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, roll: Float) {}
-    fun onDidFovCamera(view: PLIView?, sender: Any?, camera: PLICamera?, fov: Float, animated: Boolean) {}
-    fun onDidOverElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidClickElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidOutElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidOverHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidClickHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidOutHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidBeginTransition(view: PLIView?, transition: PLITransition?) {}
-    fun onDidProcessTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
-    fun onDidStopTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
-    fun onDidEndTransition(view: PLIView?, transition: PLITransition?) {}
-    fun onDidBeginLoader(view: PLIView?, loader: PLILoader?) {}
-    fun onDidCompleteLoader(view: PLIView?, loader: PLILoader?) {}
-    fun onDidStopLoader(view: PLIView?, loader: PLILoader?) {}
-    fun onDidErrorLoader(view: PLIView?, loader: PLILoader?, error: String?) {}
+    open fun onDidReset(view: PLIView?) {}
+    open fun onDidBeginCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
+    open fun onDidEndCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
+    open fun onDidResetCamera(view: PLIView?, sender: Any?, camera: PLICamera?) {}
+    open fun onDidLookAtCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, animated: Boolean) {}
+    open fun onDidRotateCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, roll: Float) {}
+    open fun onDidFovCamera(view: PLIView?, sender: Any?, camera: PLICamera?, fov: Float, animated: Boolean) {}
+    open fun onDidOverElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidClickElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidOutElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidOverHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidClickHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidOutHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidBeginTransition(view: PLIView?, transition: PLITransition?) {}
+    open fun onDidProcessTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
+    open fun onDidStopTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
+    open fun onDidEndTransition(view: PLIView?, transition: PLITransition?) {}
+    open fun onDidBeginLoader(view: PLIView?, loader: PLILoader?) {}
+    open fun onDidCompleteLoader(view: PLIView?, loader: PLILoader?) {}
+    open fun onDidStopLoader(view: PLIView?, loader: PLILoader?) {}
+    open fun onDidErrorLoader(view: PLIView?, loader: PLILoader?, error: String?) {}
 }


### PR DESCRIPTION
I just add the support for the Device orientation, in my use case the app is in landscape and your library does not work right with that.
It turns out that you already have a property for that `mCurrentDeviceOrientation` but it is private and set to Portrait in initialization. 
So i add the evaluation of this in the initial block of the PLManager class, with this the library now also works great in Landscape.

Also i change your PLViewListener methods to be open, otherwise it is not possible to override them in kotlin