### PR TITLE
Remove NDK warning

### DIFF
--- a/library/src/main/jni/com_panoramagl_opengl_GLUES.c
+++ b/library/src/main/jni/com_panoramagl_opengl_GLUES.c
@@ -73,7 +73,7 @@ void gluesCallErrorCallback(JNIEnv *env, jclass sclass, jobject qobj)
 		jmethodID methodID = (*env)->GetStaticMethodID(env, sclass, "gluQuadricError", "(Lcom/panoramagl/opengl/GLUquadric;I)V");
 		if (methodID)
 		{
-			(*env)->CallStaticVoidMethod(env, sclass, methodID, (jvalue*)qobj, (jvalue*)(jint)gluesErrorCode);
+			(*env)->CallStaticVoidMethod(env, sclass, methodID, qobj, gluesErrorCode);
 		}
 		gluesErrorCode = GLUES_ERROR_CODE;
 	}


### PR DESCRIPTION
The issue is that `CallStaticVoidMethod` takes variadic args directly — the `(jvalue)` casts are wrong and unnecessary. 
The `jvalue` version would be `CallStaticVoidMethodA`. 

Removed the bogus `(jvalue)` casts — `CallStaticVoidMethod` is variadic and takes `jobject` and `jint` directly. The warning is gone and the behavior is unchanged.